### PR TITLE
Add sitemap.xml + robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.remoet.dev/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://docs.remoet.dev/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://docs.remoet.dev/about</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://docs.remoet.dev/education</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://docs.remoet.dev/full</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://docs.remoet.dev/get-started</loc><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://docs.remoet.dev/get-started/authorization</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://docs.remoet.dev/hello</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://docs.remoet.dev/jobs</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://docs.remoet.dev/links</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://docs.remoet.dev/linktrees</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://docs.remoet.dev/projects</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://docs.remoet.dev/starter-template</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+</urlset>


### PR DESCRIPTION
Vercel runtime logs showed crawlers 404'ing /sitemap.xml, /sitemap_index.xml, /sitemap.xml.gz, /sitemaps.xml, /sitemap.txt multiple times per day. Docs had no sitemap.

Static file covers the 12 MDX pages currently in content/. Maintenance: update when content/ tree changes. Nextra doesn't auto-generate a sitemap, so a static file is the cheapest path while the content count stays small. If pages keep growing, swap to next-sitemap later.